### PR TITLE
Update citeSIMONAPublications.rst

### DIFF
--- a/GuideLines/citeSIMONAPublications.rst
+++ b/GuideLines/citeSIMONAPublications.rst
@@ -28,18 +28,18 @@ SIMONA publications
 Recent publications using SIMONA
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. `(2022). Modelling peptide adsorption energies on gold surfaces with an effective implicit solvent and surface model <https://doi.org/10.1016/j.jcis.2021.07.090/>`_
-#. `(2021). Monte-Carlo Simulations of Soft Matter using SIMONA: A review of recent applications <https://doi.org/10.3389/fphy.2021.635959/>`_
-#. `(2020). Sampling of the conformational landscape of small proteins with Monte Carlo methods <https://doi.org/10.1038/s41598-020-75239-7/>`_
-#. `(2020). Tacticity dependence of single chain polymer folding <https://doi.org/10.1039/D0PY00133C/>`_
-#. `(2019). Rational Design of Iron Oxide Binding Peptide Tags <https://doi.org/10.1021/acs.langmuir.9b00729/>`_
-#. `(2015). Modelling of reversible single chain polymer self-assembly: from the polymer towards the protein limit <https://doi.org/10.1039/C4CC10243F/>`_
-#. `(2012). SIMONA 1.0: An efficient and versatile framework for stochastic simulations of molecular and nanoscale systems <https://doi.org/10.1002/jcc.23089/>`_
+#. `(2022). Modelling peptide adsorption energies on gold surfaces with an effective implicit solvent and surface model <https://doi.org/10.1016/j.jcis.2021.07.090>`_
+#. `(2021). Monte-Carlo Simulations of Soft Matter using SIMONA: A review of recent applications <https://doi.org/10.3389/fphy.2021.635959>`_
+#. `(2020). Sampling of the conformational landscape of small proteins with Monte Carlo methods <https://doi.org/10.1038/s41598-020-75239-7>`_
+#. `(2020). Tacticity dependence of single chain polymer folding <https://doi.org/10.1039/D0PY00133C>`_
+#. `(2019). Rational Design of Iron Oxide Binding Peptide Tags <https://doi.org/10.1021/acs.langmuir.9b00729>`_
+#. `(2015). Modelling of reversible single chain polymer self-assembly: from the polymer towards the protein limit <https://doi.org/10.1039/C4CC10243F>`_
+#. `(2012). SIMONA 1.0: An efficient and versatile framework for stochastic simulations of molecular and nanoscale systems <https://doi.org/10.1002/jcc.23089>`_
 
 
 Algorithm publications implemented in SIMONA
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. `PowerBorn <https://pubs.acs.org/doi/10.1021/ct300870s/>`_
-#. `PowerSASA <https://onlinelibrary.wiley.com/doi/full/10.1002/jcc.21844/>`_
-#. `AroMoCa <https://onlinelibrary.wiley.com/doi/full/10.1002/jcc.24205/>`_
+#. `PowerBorn <https://doi.org/10.1021/ct300870s>`_
+#. `PowerSASA <https://doi.org/10.1002/jcc.21844>`_
+#. `AroMoCa <https://doi.org/10.1002/jcc.24205>`_


### PR DESCRIPTION
Fix DOI URLS so that they work. doi.org does not want a trailing forward slash after the DOI.

Also edited three URLs with DOIs in them to point directly at doi.org